### PR TITLE
Add excerpt field, to be used as teaser, to articles

### DIFF
--- a/app/controllers/spina/admin/articles_controller.rb
+++ b/app/controllers/spina/admin/articles_controller.rb
@@ -57,7 +57,7 @@ module Spina
       end
 
       def article_params
-        params.require(:article).permit(:title, :subtitle, :content, :draft,
+        params.require(:article).permit(:title, :subtitle, :content, :excerpt, :draft,
                                         :publish_date, :spina_category_id,
                                         :header_photo, :seo_title, :meta_description)
       end

--- a/app/views/spina/admin/articles/_form.html.haml
+++ b/app/views/spina/admin/articles/_form.html.haml
@@ -22,6 +22,11 @@
             = render 'spina/admin/shared/rich_text_field', form: f, field: :content
         %tr
           %td
+            Excerpt
+          %td
+            = f.text_area :excerpt
+        %tr
+          %td
             SEO title
           %td
             = f.text_field :seo_title

--- a/lib/generators/spina_articles/install_generator.rb
+++ b/lib/generators/spina_articles/install_generator.rb
@@ -17,6 +17,7 @@ module SpinaArticles
 
       def copy_migration_file
         migration_template "create_spina_articles_tables.rb", Rails.root.join("db/migrate/create_spina_articles_tables.rb")
+        migration_template "add_excerpt_to_articles.rb", Rails.root.join("db/migrate/add_excerpt_to_articles.rb")
       end
 
       def run_migrations

--- a/lib/generators/spina_articles/templates/add_excerpt_to_articles.rb
+++ b/lib/generators/spina_articles/templates/add_excerpt_to_articles.rb
@@ -1,0 +1,5 @@
+class AddExcerptToArticles < ActiveRecord::Migration
+  def change
+    add_column :spina_articles, :excerpt, :text
+  end
+end


### PR DESCRIPTION
Sometimes we want to display a teaser of articles on the index page, and not the full articles
