### PR TITLE
routes should be loaded ahead of spina's catch all route definition

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spina::Engine.routes.draw do
+Spina::Engine.routes.prepend do
   namespace :admin do
     resources :articles, :categories
   end

--- a/lib/spina/articles/engine.rb
+++ b/lib/spina/articles/engine.rb
@@ -16,6 +16,12 @@ module Spina
         plugin.config = Articles.config
         ::Spina.register_plugin(plugin)
       end
+
+      config.after_initialize do
+        # Since in routes.rb we are using prepend, we need to reload routes
+        # Otherwise, spina's /*id routes will prevent us to ever get to our routes
+        Rails.application.routes_reloader.reload!
+      end
     end
   end
 end


### PR DESCRIPTION
this is related to this issue: https://github.com/Design-Collective/spina-blog/issues/2
